### PR TITLE
OIS-59: localStorage data must be cleared after logout

### DIFF
--- a/src/openlmis-logout/openlmis-logout.controller.js
+++ b/src/openlmis-logout/openlmis-logout.controller.js
@@ -58,6 +58,11 @@
         function doLogout() {
             loginService.logout()
                 .then(function() {
+                    var currentLocale = localStorage.getItem('openlmis.current_locale');
+                    localStorage.clear();
+                    localStorage.setItem('openlmis.current_locale', currentLocale);
+                })
+                .then(function() {
                     $rootScope.$emit('openlmis-auth.logout');
                     $state.go('auth.login');
                 });


### PR DESCRIPTION
[OIS-59](https://openlmis.atlassian.net/browse/OIS-59)

Changes:
- localStorage data must be cleared after logout, but keeps used language

[OIS-59]: https://openlmis.atlassian.net/browse/OIS-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ