### PR TITLE
OLMIS-8043: Close offline modal on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Improvements:
 * [OLMIS-8218](https://openlmis.atlassian.net/browse/OLMIS-8218): Show password icon on login page
 * [SELV3-748](https://openlmis.atlassian.net/browse/SELV3-748) Improved 'no permission' warning message
 
+Bug fixes:
+* [OLMIS-8043](https://openlmis.atlassian.net/browse/OLMIS-8043): Close the offline modal automatically when the connection is restored.
+
 6.2.17 / 2026-02-05
 =================
 Improvements:

--- a/src/openlmis-navigation/offline-navigation.interceptor.js
+++ b/src/openlmis-navigation/offline-navigation.interceptor.js
@@ -32,13 +32,25 @@
     ];
 
     function offlineNavigationInterceptor($rootScope, alertService, loadingModalService, offlineService, $state) {
+        var offlineAlertPending = false;
+
         $rootScope.$on('$stateChangeStart', checkOffline);
+        $rootScope.$on('openlmis.online', closeOfflineAlert);
 
         function checkOffline(event, toState, toStateParams, fromState, fromStateParams, options) {
             if (shouldPreventStateChange(toState, fromState, options)) {
                 event.preventDefault();
                 loadingModalService.close();
-                alertService.error('openlmisNavigation.notAvailableOffline');
+                offlineAlertPending = true;
+                alertService.error('openlmisNavigation.notAvailableOffline').finally(function() {
+                    offlineAlertPending = false;
+                });
+            }
+        }
+
+        function closeOfflineAlert() {
+            if (offlineAlertPending) {
+                alertService.close();
             }
         }
 

--- a/src/openlmis-navigation/offline-navigation.interceptor.js
+++ b/src/openlmis-navigation/offline-navigation.interceptor.js
@@ -41,10 +41,12 @@
             if (shouldPreventStateChange(toState, fromState, options)) {
                 event.preventDefault();
                 loadingModalService.close();
-                offlineAlertPending = true;
-                alertService.error('openlmisNavigation.notAvailableOffline').finally(function() {
-                    offlineAlertPending = false;
-                });
+                if (!offlineAlertPending) {
+                    offlineAlertPending = true;
+                    alertService.error('openlmisNavigation.notAvailableOffline').finally(function() {
+                        offlineAlertPending = false;
+                    });
+                }
             }
         }
 

--- a/src/openlmis-navigation/offline-navigation.interceptor.spec.js
+++ b/src/openlmis-navigation/offline-navigation.interceptor.spec.js
@@ -60,11 +60,14 @@ describe('Offline navigation interceptor', function() {
             this.loadingModalService = $injector.get('loadingModalService');
             this.offlineService = $injector.get('offlineService');
             this.$rootScope = $injector.get('$rootScope');
+            this.$q = $injector.get('$q');
         });
 
         this.isOffline = false;
+        this.alertDeferred = this.$q.defer();
 
-        spyOn(this.alertService, 'error');
+        spyOn(this.alertService, 'error').andReturn(this.alertDeferred.promise);
+        this.alertService.close = jasmine.createSpy('close');
         spyOn(this.loadingModalService, 'close');
 
         var context = this;
@@ -152,6 +155,38 @@ describe('Offline navigation interceptor', function() {
         this.$state.go('parent.child.left');
 
         expect(this.alertService.error).toHaveBeenCalled();
+    });
+
+    it('will close the offline alert when going online', function() {
+        this.isOffline = true;
+        this.$state.go('normal');
+        this.$rootScope.$apply();
+
+        expect(this.alertService.error).toHaveBeenCalled();
+        expect(this.alertService.close).not.toHaveBeenCalled();
+
+        this.$rootScope.$broadcast('openlmis.online');
+
+        expect(this.alertService.close).toHaveBeenCalled();
+    });
+
+    it('will not close any alert on online event if no offline alert was opened', function() {
+        this.$rootScope.$broadcast('openlmis.online');
+
+        expect(this.alertService.close).not.toHaveBeenCalled();
+    });
+
+    it('will not close an already-dismissed offline alert on subsequent online event', function() {
+        this.isOffline = true;
+        this.$state.go('normal');
+        this.$rootScope.$apply();
+
+        this.alertDeferred.resolve();
+        this.$rootScope.$apply();
+
+        this.$rootScope.$broadcast('openlmis.online');
+
+        expect(this.alertService.close).not.toHaveBeenCalled();
     });
 
 });


### PR DESCRIPTION
The offline navigation modal now closes automatically when the connection is restored.